### PR TITLE
Phase 1 & 2: bug fixes, AP password, DST offset, Fermentrack, BierBot

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,75 @@
+# iSpindHub — Testing TODO (PR #14)
+
+Branch: `fix/phase1-bugs`  
+PR: https://github.com/ZeSlammy/iSpindHub/pull/14
+
+Flash each env with `pio run -e <env> -t upload` and `pio run -e <env> -t uploadfs`.
+
+---
+
+## Phase 1 — Bug fixes
+
+### #13 Root serves "Hello World" instead of web UI
+- [ ] Flash any env
+- [ ] Open `http://<hub-ip>/` in a browser
+- **Pass**: dashboard loads (not plain "Hello World")
+
+### #12 Version mismatch
+- [ ] Open `http://<hub-ip>/thisVersion/` — confirm `"version": "0.0.9"`
+
+### #9 ILI9341 white screen (2.4" display)
+- [ ] Flash `2_4_inches_ILI9341` env
+- **Pass**: display shows iSpindel data (SG, temp, battery, etc.)
+- **If colours are inverted**: remove `-DTFT_INVERSION_ON=1` from `platformio.ini` env and reflash
+
+---
+
+## Phase 2 — New features
+
+### #7 AP WiFi password
+- [ ] Go to **Settings → Advanced → Access Point**
+- [ ] Enter a passphrase (8–63 chars) and save
+- [ ] Reboot the hub
+- **Pass**: the `iSpindHub` WiFi network is now WPA2 protected — phones/laptops prompt for the passphrase
+- Edge case: set passphrase back to empty → AP returns to open (no password)
+
+### #6 DST offset
+- [ ] Go to **Settings → iSpindHub**, set DST to **+1 hour**, click Update
+- [ ] Check `/iSpindInfo/` or the display — timestamps should be 1 hour ahead of UTC+TZ
+- [ ] Set DST back to **No DST** — timestamps return to standard offset
+- Note: this is a *manual* toggle. Change it twice a year (spring forward / fall back).
+
+### #8 Fermentrack push
+- [ ] Go to **Settings → Targets → Fermentrack**
+- [ ] Enter your Fermentrack base URL (e.g. `http://fermentrack.local`) and frequency (e.g. 15 min)
+- [ ] Wait for the push interval to expire
+- **Pass**: gravity reading appears in Fermentrack under the iSpindel device
+- Edge case: empty URL → push is silently skipped (no crash)
+
+### #2 BierBot Bricks push
+- [ ] Go to **Settings → Targets → BierBot**
+- [ ] Enter your BierBot API key and frequency
+- [ ] Wait for the push interval
+- **Pass**: telemetry appears in BierBot app for the device
+- Note: uses HTTPS with no certificate validation (`setInsecure()`). If BierBot returns non-200, check the Serial monitor for the status line.
+
+---
+
+## Issues to close after testing
+
+Once hardware-confirmed, close these with the linked PR:
+
+| Issue | How to close |
+|-------|--------------|
+| #13 | Close — fixed by removing dead `server.on("/")` handler |
+| #12 | Close — version bumped, dead code removed |
+| #9  | Close — pin TFT_eSPI + ILI9341 flags; note inversion toggle |
+| #7  | Close — AP passphrase wired in, settings UI added |
+| #6  | Close — manual DST offset field added |
+| #8  | Close — Fermentrack push target implemented |
+| #2  | Close — BierBot Bricks target implemented |
+
+## Issues to close with a comment (no code needed)
+
+- **#11 (ESP-Now)**: Good idea, but requires coordinated firmware changes in the iSpindel itself — can't be done unilaterally in the hub. Mark as `enhancement / help wanted`.
+- **#4 (Repeater question)**: The hub already operates in WIFI_AP_STA mode (repeater). Littlebock/generic URL targets handle external software forwarding. Answer the question and close.

--- a/data/settings.htm
+++ b/data/settings.htm
@@ -157,6 +157,12 @@
                 <a class="dropdown-item" data-toggle="tab" href="#brewfather"
                   >Brewfather</a
                 >
+                <a class="dropdown-item" data-toggle="tab" href="#fermentrack"
+                  >Fermentrack</a
+                >
+                <a class="dropdown-item" data-toggle="tab" href="#bierbot"
+                  >BierBot</a
+                >
               </div>
             </li>
             <!-- Targets Nav Item -->
@@ -176,6 +182,9 @@
                   >Reset</a
                 >
                 <a class="dropdown-item" data-toggle="tab" href="#wifi">Wifi</a>
+                <a class="dropdown-item" data-toggle="tab" href="#apconfig"
+                  >Access Point</a
+                >
               </div>
             </li>
             <!-- Advanced Nav Item -->
@@ -259,6 +268,27 @@
                             id="ispindhubTZ"
                             name="ispindhubTZ"
                           ></select>
+                        </div>
+                      </div>
+                      <div class="form-group row">
+                        <label
+                          for="ispindhubDST"
+                          class="col-sm-3 col-form-label"
+                          data-toggle="tooltip"
+                          title="DST hour offset added on top of the base timezone"
+                        >
+                          DST Offset
+                        </label>
+                        <div class="col-sm-9">
+                          <select
+                            class="form-control"
+                            id="ispindhubDST"
+                            name="ispindhubDST"
+                          >
+                            <option value="0">No DST (standard time)</option>
+                            <option value="1">+1 hour</option>
+                            <option value="2">+2 hours</option>
+                          </select>
                         </div>
                       </div>
                       <div class="row col-sm-12 justify-content-center">
@@ -808,6 +838,247 @@
               </div>
             </div>
             <!-- Wifi Reset tab -->
+
+            <!-- AP Config tab -->
+            <div class="tab-pane fade" id="apconfig">
+              <div class="card-header">
+                <h4 class="card-title">Access Point Settings</h4>
+              </div>
+              <div class="card-body">
+                <ul class="list-group list-group-flush">
+                  <li class="list-group-item">
+                    <p class="card-text">
+                      Configure the SSID and optional passphrase for the
+                      iSpindHub soft access point. Leave passphrase empty for an
+                      open AP.
+                    </p>
+                    <form
+                      class="form-group"
+                      id="apconfig"
+                      action="/settings/apconfig/"
+                      method="POST"
+                      onsubmit="return processPost(this);"
+                    >
+                      <div class="form-group row">
+                        <label
+                          for="apssid"
+                          class="col-sm-3 col-form-label"
+                          data-toggle="tooltip"
+                          title="SSID for the access point (3-32 characters)"
+                        >
+                          SSID
+                        </label>
+                        <div class="col-sm-9">
+                          <input
+                            type="text"
+                            class="form-control"
+                            id="apssid"
+                            name="apssid"
+                            minlength="3"
+                            maxlength="32"
+                            placeholder="iSpindHub"
+                          />
+                        </div>
+                      </div>
+                      <div class="form-group row">
+                        <label
+                          for="appassphrase"
+                          class="col-sm-3 col-form-label"
+                          data-toggle="tooltip"
+                          title="Passphrase for the access point (8-63 characters, or empty for open AP)"
+                        >
+                          Passphrase
+                        </label>
+                        <div class="col-sm-9">
+                          <input
+                            type="text"
+                            class="form-control"
+                            id="appassphrase"
+                            name="appassphrase"
+                            maxlength="63"
+                            placeholder="leave empty for open AP"
+                          />
+                        </div>
+                      </div>
+                      <div class="row col-sm-12 justify-content-center">
+                        <button
+                          class="btn btn-primary"
+                          id="submitSettings"
+                          onclick="if(!this.form.checkValidity(this)){return (false);}"
+                        >
+                          Update
+                        </button>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <!-- AP Config tab -->
+
+            <!-- Fermentrack Settings tab -->
+            <div class="tab-pane fade" id="fermentrack">
+              <div class="card-header">
+                <h4 class="card-title">Fermentrack Target Settings</h4>
+              </div>
+              <div class="card-body">
+                <ul class="list-group list-group-flush">
+                  <li class="list-group-item">
+                    <p class="card-text">
+                      These settings control how iSpindHub forwards iSpindel
+                      information to a self-hosted
+                      <a href="https://www.fermentrack.com/">Fermentrack</a>
+                      instance. To disable pushing to Fermentrack, delete the
+                      URL.
+                    </p>
+
+                    <form
+                      class="form-group"
+                      id="fermentrack"
+                      action="/settings/fermentracktarget/"
+                      method="POST"
+                      onsubmit="return processPost(this);"
+                    >
+                      <div class="form-group row">
+                        <label
+                          for="fermentrackurl"
+                          class="col-sm-3 col-form-label"
+                          data-toggle="tooltip"
+                          title="Base URL of your Fermentrack instance. Delete to disable."
+                        >
+                          URL
+                        </label>
+                        <div class="col-sm-9">
+                          <input
+                            type="url"
+                            class="form-control"
+                            id="fermentrackurl"
+                            name="fermentrackurl"
+                            minlength="3"
+                            maxlength="128"
+                            placeholder="http://fermentrack.local"
+                          />
+                        </div>
+                      </div>
+
+                      <div class="form-group row">
+                        <label
+                          for="fermentrackfreq"
+                          class="col-sm-3 col-form-label"
+                          data-toggle="tooltip"
+                          title="How often (in minutes) to push data to Fermentrack"
+                          >Push Frequency</label
+                        >
+                        <div class="col-sm-9">
+                          <input
+                            type="number"
+                            class="form-control"
+                            id="fermentrackfreq"
+                            name="fermentrackfreq"
+                            placeholder="15"
+                            min="1"
+                            max="60"
+                          />
+                        </div>
+                      </div>
+
+                      <div class="row col-sm-12 justify-content-center">
+                        <button
+                          class="btn btn-primary"
+                          id="submitSettings"
+                          onclick="if(!this.form.checkValidity(this)){return (false);}"
+                        >
+                          Update
+                        </button>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <!-- Fermentrack Settings tab -->
+
+            <!-- BierBot Settings tab -->
+            <div class="tab-pane fade" id="bierbot">
+              <div class="card-header">
+                <h4 class="card-title">BierBot Target Settings</h4>
+              </div>
+              <div class="card-body">
+                <ul class="list-group list-group-flush">
+                  <li class="list-group-item">
+                    <p class="card-text">
+                      These settings control how iSpindHub forwards iSpindel
+                      information to
+                      <a href="https://www.bierbot.com/">BierBot Bricks</a>.
+                      To disable pushing to BierBot, delete the key.
+                    </p>
+
+                    <form
+                      class="form-group"
+                      id="bierbot"
+                      action="/settings/bierbottarget/"
+                      method="POST"
+                      onsubmit="return processPost(this);"
+                    >
+                      <div class="form-group row">
+                        <label
+                          for="bierbotkey"
+                          class="col-sm-3 col-form-label"
+                          data-toggle="tooltip"
+                          title="Enter the API key from your BierBot account. To disable pushing to BierBot, delete the key."
+                        >
+                          API Key
+                        </label>
+                        <div class="col-sm-9">
+                          <input
+                            type="text"
+                            class="form-control"
+                            id="bierbotkey"
+                            name="bierbotkey"
+                            minlength="10"
+                            maxlength="64"
+                            placeholder="your-bierbot-api-key"
+                          />
+                        </div>
+                      </div>
+
+                      <div class="form-group row">
+                        <label
+                          for="bierbotfreq"
+                          class="col-sm-3 col-form-label"
+                          data-toggle="tooltip"
+                          title="How often (in minutes) to push data to BierBot"
+                          >Push Frequency</label
+                        >
+                        <div class="col-sm-9">
+                          <input
+                            type="number"
+                            class="form-control"
+                            id="bierbotfreq"
+                            name="bierbotfreq"
+                            placeholder="15"
+                            min="2"
+                            max="120"
+                          />
+                        </div>
+                      </div>
+
+                      <div class="row col-sm-12 justify-content-center">
+                        <button
+                          class="btn btn-primary"
+                          id="submitSettings"
+                          onclick="if(!this.form.checkValidity(this)){return (false);}"
+                        >
+                          Update
+                        </button>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <!-- BierBot Settings tab -->
+
           </div>
           <!-- Nav Tab Content -->
         </div>

--- a/data/settings.js
+++ b/data/settings.js
@@ -89,12 +89,19 @@ function populateForm() { // Get current parameters
                 $('#mdnsid').val(config.hostname);
                 $('#ispindhubname').val(config.ispindhub.name);
                 $('#ispindhubTZInfo').val(config.ispindhub.TZ);
+                $('#ispindhubDST').val(config.ispindhub.dst_offset);
                 $('#urltargeturl').val(config.urltarget.url);
                 $('#urlfreq').val(config.urltarget.freq);
                 $('#brewersfriendkey').val(config.brewersfriend.key);
                 $('#brewersfriendfreq').val(config.brewersfriend.freq);
                 $('#brewfatherkey').val(config.brewfather.key);
                 $('#brewfatherfreq').val(config.brewfather.freq);
+                $('#apssid').val(config.apconfig.ssid);
+                $('#appassphrase').val(config.apconfig.passphrase);
+                $('#fermentrackurl').val(config.fermentrack.url);
+                $('#fermentrackfreq').val(config.fermentrack.freq);
+                $('#bierbotkey').val(config.bierbot.key);
+                $('#bierbotfreq').val(config.bierbot.freq);
             } catch {
                 if (!unloadingState) {
                     alert("Unable to parse configuration data.");
@@ -157,6 +164,15 @@ function processPost(obj) {
         case "#thingspeak":
             processThingSpeakPost(url, obj, 8);
             break;
+        case "#apconfig":
+            processApConfigPost(url, obj);
+            break;
+        case "#fermentrack":
+            processFermentrackPost(url, obj);
+            break;
+        case "#bierbot":
+            processBierBotPost(url, obj);
+            break;
         default:
             // Unknown hash location passed
             break;
@@ -181,11 +197,13 @@ function processiSpindHubPost(url, obj) {
     var $form = $(obj),
         ispindhubname = $form.find("input[name='ispindhubname']").val();
         ispindhubTZ = $form.find("select[name='ispindhubTZ'").val();
+        ispindhubDST = $form.find("select[name='ispindhubDST'").val();
 
     // Process post
     data = {
         ispindhubname: ispindhubname,
-        ispindhubTZ : ispindhubTZ
+        ispindhubTZ : ispindhubTZ,
+        ispindhubDST : ispindhubDST
     };
     postData(url, data);
 }
@@ -269,6 +287,54 @@ function processThingSpeakPost(url, obj) {
         thingspeakchannel: thingspeakchannel,
         thingspeakkey: thingspeakkey,
         thingspeakfreq: thingspeakfreq
+    };
+    postData(url, data);
+}
+
+function processApConfigPost(url, obj) {
+    // Handle AP Config posts
+
+    // Get form data
+    var $form = $(obj),
+        apssid = $form.find("input[name='apssid']").val(),
+        appassphrase = $form.find("input[name='appassphrase']").val();
+
+    // Process post
+    data = {
+        apssid: apssid,
+        appassphrase: appassphrase
+    };
+    postData(url, data);
+}
+
+function processFermentrackPost(url, obj) {
+    // Handle Fermentrack target posts
+
+    // Get form data
+    var $form = $(obj),
+        fermentrackurl = $form.find("input[name='fermentrackurl']").val(),
+        fermentrackfreq = $form.find("input[name='fermentrackfreq']").val();
+
+    // Process post
+    data = {
+        fermentrackurl: fermentrackurl,
+        fermentrackfreq: fermentrackfreq
+    };
+    postData(url, data);
+}
+
+function processBierBotPost(url, obj) {
+    // Handle BierBot target posts
+
+    // Get form data
+    var $form = $(obj),
+        bierbotkey = $form.find("input[name='bierbotkey']").val(),
+        bierbotfreq = $form.find("input[name='bierbotfreq']").val();
+
+    // Process post
+    data = {
+        bierbotkey: bierbotkey,
+        bierbotfreq: bierbotfreq
     };
     postData(url, data);
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,13 +31,13 @@ lib_deps =
 	arduino-libraries/NTPClient@^3.1.0
 	paulstoffregen/Time@^1.6
 	bblanchon/StreamUtils@^1.6.3
-	bodmer/TFT_eSPI@^2.3.67
+	bodmer/TFT_eSPI@2.5.43
 	arkhipenko/Dictionary @ ^3.5.0
 	khoih-prog/ESPAsync_WiFiManager
 lib_ldf_mode = chain
 board_build.filesystem = littlefs
 build_flags = 
-	-DPIO_SRC_TAG="0.0.7"
+	-DPIO_SRC_TAG="0.0.9"
 	-DPIO_SRC_REV="Dev"
 
 [env:2_inches]
@@ -186,7 +186,7 @@ build_flags =
 
 [env:2_4_inches_ILI9341]
 board_build.filesystem = littlefs
-build_flags = 
+build_flags =
 	${env.build_flags}
 	-DPIO_SRC_BRH="2.4 Inches ILI9341"
 	-DUSER_SETUP_LOADED=1
@@ -209,6 +209,8 @@ build_flags =
 	-DTFT_RST=PIN_D2
 	-DTFT_BL=PIN_D4
 	-DTFT_BACKLIGHT_ON=LOW
+	-DTFT_RGB_ORDER=TFT_BGR
+	-DTFT_INVERSION_ON=1
 	-D USE_LITTLEFS
 	-std=c99
 

--- a/src/cronpush.cpp
+++ b/src/cronpush.cpp
@@ -101,3 +101,130 @@ void pushBrewFather()
         Serial.println("No BF Key, no Push");
     }
 }
+
+void pushFermentrack()
+{
+    if (strlen(config.fermentrack.url) == 0)
+    {
+        return;
+    }
+
+    StaticJsonDocument<400> payload;
+    FSInfo fs_info;
+    LittleFS.info(fs_info);
+    Dir dir = LittleFS.openDir("/data");
+    String ft_url = String(config.fermentrack.url) + "/api/gravity/";
+    Serial.println(ft_url);
+    WiFiClient client;
+    HTTPClient http;
+
+    while (dir.next())
+    {
+        http.begin(client, ft_url);
+        http.addHeader("Content-Type", "application/json");
+        http.addHeader("Cache-Control", "no-cache");
+        String json;
+        String f_name = dir.fileName();
+        f_name.remove(f_name.length() - 4);
+        if (dir.fileSize())
+        {
+            File file = dir.openFile("r");
+            String temp = file.readStringUntil('\r');
+            int line_len = temp.length() + 1;
+            file.seek(line_len, SeekEnd);
+            String lastData = file.readString();
+            file.close();
+            int str_len = lastData.length() + 1;
+            int count = 0;
+            int idx;
+            int mov_idx = 0;
+            String array_data[10] = {};
+            for (idx = 0; idx <= str_len; idx++)
+            {
+                if (lastData[idx] == ',')
+                {
+                    array_data[count] = lastData.substring(mov_idx, idx);
+                    mov_idx = idx + 1;
+                    count++;
+                }
+            }
+            payload["name"] = array_data[1];
+            payload["angle"] = array_data[2];
+            payload["temperature"] = array_data[3];
+            payload["battery"] = array_data[4];
+            payload["gravity"] = array_data[5];
+            payload["interval"] = array_data[6];
+            payload["RSSI"] = array_data[7];
+            payload["temp_units"] = array_data[8];
+            serializeJson(payload, json);
+            http.POST(json);
+            Serial.print(http.getString());
+            delay(5000);
+            http.end();
+        }
+    }
+}
+
+void pushBierBot()
+{
+    if (strlen(config.bierbot.key) == 0)
+    {
+        return;
+    }
+
+    StaticJsonDocument<400> payload;
+    FSInfo fs_info;
+    LittleFS.info(fs_info);
+    Dir dir = LittleFS.openDir("/data");
+    String bb_key = config.bierbot.key;
+    String bb_url = String("https://app.bierbot.com/api/anubis/v1/telemetry?apikey=") + bb_key;
+    Serial.println(bb_url);
+
+    while (dir.next())
+    {
+        String json;
+        String f_name = dir.fileName();
+        f_name.remove(f_name.length() - 4);
+        if (dir.fileSize())
+        {
+            File file = dir.openFile("r");
+            String temp = file.readStringUntil('\r');
+            int line_len = temp.length() + 1;
+            file.seek(line_len, SeekEnd);
+            String lastData = file.readString();
+            file.close();
+            int str_len = lastData.length() + 1;
+            int count = 0;
+            int idx;
+            int mov_idx = 0;
+            String array_data[10] = {};
+            for (idx = 0; idx <= str_len; idx++)
+            {
+                if (lastData[idx] == ',')
+                {
+                    array_data[count] = lastData.substring(mov_idx, idx);
+                    mov_idx = idx + 1;
+                    count++;
+                }
+            }
+            payload["type"] = "iSpindel";
+            payload["id"] = array_data[1];
+            payload["status"] = "0";
+            payload["angle"] = array_data[2];
+            payload["gravity"] = array_data[5];
+            payload["temp_celsius"] = array_data[3];
+            payload["battery"] = array_data[4];
+            serializeJson(payload, json);
+            WiFiClientSecure secureClient;
+            secureClient.setInsecure();
+            HTTPClient http;
+            http.begin(secureClient, bb_url);
+            http.addHeader("Content-Type", "application/json");
+            http.addHeader("Cache-Control", "no-cache");
+            http.POST(json);
+            Serial.print(http.getString());
+            delay(5000);
+            http.end();
+        }
+    }
+}

--- a/src/cronpush.h
+++ b/src/cronpush.h
@@ -4,8 +4,12 @@
 #include <ArduinoJson.h>
 #include <AsyncJson.h>
 #include <ESP8266HTTPClient.h>
+#include <ESP8266WiFi.h>
+#include <WiFiClientSecure.h>
 #include <WiFiUdp.h>
 #include "wifi.h"
 
 #endif
 void pushBrewFather();
+void pushFermentrack();
+void pushBierBot();

--- a/src/jsonconfig.cpp
+++ b/src/jsonconfig.cpp
@@ -344,6 +344,7 @@ void iSpindHub::save(JsonObject obj) const
 {
     obj["name"] = name;
     obj["TZ"] = TZ;
+    obj["dst_offset"] = dst_offset;
 }
 
 void iSpindHub::load(JsonObjectConst obj)
@@ -370,6 +371,16 @@ void iSpindHub::load(JsonObjectConst obj)
         const char *tm = obj["TZ"];
         strlcpy(TZ, tm, sizeof(TZ));
     }
+
+    if (obj["dst_offset"].isNull())
+    {
+        dst_offset = 0;
+    }
+    else
+    {
+        int d = obj["dst_offset"];
+        dst_offset = d;
+    }
 }
 
 void Config::load(JsonObjectConst obj)
@@ -380,8 +391,11 @@ void Config::load(JsonObjectConst obj)
     apconfig.load(obj["apconfig"]);
     ispindhub.load(obj["ispindhub"]);
     urltarget.load(obj["urltarget"]);
+    bpiless.load(obj["bpiless"]);
+    fermentrack.load(obj["fermentrack"]);
     brewersfriend.load(obj["brewersfriend"]);
     brewfather.load(obj["brewfather"]);
+    bierbot.load(obj["bierbot"]);
 }
 
 void Config::save(JsonObject obj) const
@@ -395,8 +409,12 @@ void Config::save(JsonObject obj) const
     urltarget.save(obj["urltarget"].to<JsonObject>());
     // Add BrewPiLess object
     bpiless.save(obj["bpiless"].to<JsonObject>());
+    // Add Fermentrack object
+    fermentrack.save(obj["fermentrack"].to<JsonObject>());
     // Add Brewer's Friend object
     brewersfriend.save(obj["brewersfriend"].to<JsonObject>());
     // Add Brewfather object
     brewfather.save(obj["brewfather"].to<JsonObject>());
+    // Add BierBot object
+    bierbot.save(obj["bierbot"].to<JsonObject>());
 }

--- a/src/jsonconfig.h
+++ b/src/jsonconfig.h
@@ -13,6 +13,7 @@ struct iSpindHub
     // Stores iSpindHub configuration
     char name[32];
     char TZ[32];
+    int dst_offset;
     void load(JsonObjectConst);
     void save(JsonObject) const;
 };
@@ -58,8 +59,10 @@ struct Config
     ApConfig apconfig;
     URLTarget urltarget;
     URLTarget bpiless;
+    URLTarget fermentrack;
     KeyTarget brewersfriend;
     KeyTarget brewfather;
+    KeyTarget bierbot;
     bool nodrd;
 
     void load(JsonObjectConst);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,8 @@ String LastSeen;
 
 // Recurring jobs setup
 TickTwo BFa_timer(pushBrewFather, 900);
+TickTwo FT_timer(pushFermentrack, 900);
+TickTwo BB_timer(pushBierBot, 900);
 
 void setup()
 {
@@ -96,10 +98,10 @@ void setup()
     //isdeployed = WiFi.softAP("iSpindHub");
     if (strlen(config.ispindhub.name) == 0)
     {
-        isdeployed = WiFi.softAP(APNAME);
+        isdeployed = WiFi.softAP(APNAME, config.apconfig.passphrase);
     }
     else{
-      isdeployed = WiFi.softAP(config.ispindhub.name);
+      isdeployed = WiFi.softAP(config.ispindhub.name, config.apconfig.passphrase);
     }
     
     if (isdeployed)
@@ -118,6 +120,8 @@ void setup()
       initWebServer();
       // Serial.print("Web Server Launched");
       BFa_timer.start();
+      FT_timer.start();
+      BB_timer.start();
     }
     else
     {
@@ -165,6 +169,8 @@ void loop()
       f.close();
       //printConfig();
       BFa_timer.interval(config.brewfather.freq * 60 * 1000);
+      FT_timer.interval(config.fermentrack.freq * 60 * 1000);
+      BB_timer.interval(config.bierbot.freq * 60 * 1000);
       // free(iSpinData);
       //Serial.println("Avant delay");
       //Serial.println(BFa_timer.elapsed());

--- a/src/ntp.cpp
+++ b/src/ntp.cpp
@@ -1,6 +1,47 @@
 
 #include "ntp.h"
 
+static long tzToOffsetSeconds(const char* tz)
+{
+    struct { const char* name; long offset; } table[] = {
+        {"GMT", 0}, {"UTC", 0},
+        {"ECT", 3600}, {"CET", 3600},
+        {"EET", 7200},
+        {"ART", 7200},
+        {"EAT", 10800},
+        {"MET", 12600},
+        {"NET", 14400},
+        {"PLT", 18000},
+        {"IST", 19800},
+        {"BST", 21600},
+        {"VST", 25200},
+        {"CTT", 28800},
+        {"JST", 32400},
+        {"ACT", 34200},
+        {"AET", 36000},
+        {"SST", 39600},
+        {"NST", 43200},
+        {"MIT", -39600},
+        {"HST", -36000},
+        {"AST", -32400},
+        {"PST", -28800},
+        {"PNT", -25200}, {"MST", -25200},
+        {"CST", -21600},
+        {"EST", -18000}, {"IET", -18000},
+        {"PRT", -14400},
+        {"CNT", -12600},
+        {"AGT", -10800}, {"BET", -10800},
+        {"CAT", -3600},
+        {NULL, 0}
+    };
+    for (int i = 0; table[i].name != NULL; i++)
+    {
+        if (strcmp(tz, table[i].name) == 0)
+            return table[i].offset;
+    }
+    return 0;
+}
+
 void setClock() {
     Log.notice(F("Entering blocking loop to get NTP time."));
     char* TMZ = config.ispindhub.TZ;
@@ -12,7 +53,7 @@ void setClock() {
     }
     Serial.println(TMZ);
     Log.notice("Time Zone used is %", TMZ);
-    configTime(TMZ,"pool.ntp.org", "time.nist.gov");
+    configTime(tzToOffsetSeconds(TMZ), (long)config.ispindhub.dst_offset * 3600, "pool.ntp.org", "time.nist.gov");
     time_t nowSecs = time(nullptr);
     time_t startSecs = time(nullptr);
     int cycle = 0;
@@ -26,7 +67,7 @@ void setClock() {
             Serial.println();
 #endif
             Log.verbose(F("Re-requesting time hack."));
-            configTime(TMZ, "pool.ntp.org", "time.nist.gov");
+            configTime(tzToOffsetSeconds(TMZ), (long)config.ispindhub.dst_offset * 3600, "pool.ntp.org", "time.nist.gov");
             startSecs = time(nullptr);
             cycle++;
         }

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -1,10 +1,7 @@
 #include "web.h"
 #include "resetreasons.h"
 AsyncWebServer server(80);
-//extern Adafruit_ST7735 tft;
 
-//const size_t capacitySerial = 3 * JSON_OBJECT_SIZE(2) + JSON_OBJECT_SIZE(3) + 3 * JSON_OBJECT_SIZE(4) + JSON_OBJECT_SIZE(11);
-//const size_t capacityDeserial = capacitySerial + 810;
 const char *build() { return stringify(PIO_SRC_REV); }
 const char *branch() { return stringify(PIO_SRC_BRH); }
 const char *version() { return stringify(PIO_SRC_TAG); }
@@ -39,11 +36,8 @@ void setRegPageAliases()
     server.serveStatic("/wifi/", LittleFS, "/").setDefaultFile("wifi.htm").setCacheControl("max-age=600");
 }
 void setActionPageHandlers()
-{   server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
-        Log.notice("Connected on /");
-        request->send(200, F("text/plain"), "Hello World");
-    });
-        server.on("/wifi2/", HTTP_GET, [](AsyncWebServerRequest *request) {
+{
+    server.on("/wifi2/", HTTP_GET, [](AsyncWebServerRequest *request) {
         Log.verbose(F("Processing /wifi2/." CR));
         request->send(LittleFS, "/wifi2.htm");
         resetWifi(); // Wipe settings, reset controller
@@ -60,24 +54,15 @@ void setJsonHandlers()
             //}
 
             StaticJsonDocument<300> jdoc;
-            //ReadLoggingStream loggingStream(data, Serial);
-            //DeserializationError error = deserializeJson(jdoc, loggingStream);
             DeserializationError error = deserializeJson(jdoc, (const char*)data);
             Log.verbose(F("Parsing json from ispindel.\n"));
             if (!error) {
-                //tft.fillRect(0,0,128,20,ST7735_BLACK);
-                // Get Data from JSON 
-                float data_size = jdoc.size();
+                int data_size = jdoc.size();
                 const char* name = jdoc["name"];
-                //long id = jdoc["ID"];
                 float angle = jdoc["angle"];
                 const char* t_unit = jdoc["temp_units"];
                 float temp = jdoc["temperature"];
                 float battery = jdoc["battery"];
-                // Output iSpindel Name
-                //Serial.println("name of file");
-                //Serial.println(name);
-                //Serial.println(temp);
                 
                 // Build and open file
                 String fname = String("/data/") + String(name) + String(".csv");
@@ -204,15 +189,6 @@ void setJsonHandlers()
         int size_info = file_info.length()-1;
         file_info.remove(size_info,1);
         file_info+= "}";
-        //Serial.print(file_info);
-        //const size_t capacity = JSON_OBJECT_SIZE(8) + 210;
-        //StaticJsonDocument<capacity> doc;
-        //JsonObject root = doc.to<JsonObject>();
-        //Serial.print(root);
-        //String json;
-        //serializeJsonPretty(doc, json);
-
-        //request->send(200, F("application/json"), json);
         request->send(200, F("application/json"), file_info);
     });
     // JSON Handlers

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -386,6 +386,57 @@ void setSettingsAliases()
         request->send(405, F("text/plain"), F("Method not allowed."));
     });
 
+    server.on("/settings/apconfig/", HTTP_POST, [](AsyncWebServerRequest *request) {
+        Log.verbose(F("Processing post to /settings/apconfig/." CR));
+        if (handleApConfigPost(request))
+        {
+            request->send(200, F("text/plain"), F("Ok"));
+        }
+        else
+        {
+            request->send(500, F("text/plain"), F("Unable to process data"));
+        }
+    });
+
+    server.on("/settings/apconfig/", HTTP_ANY, [](AsyncWebServerRequest *request) {
+        Log.verbose(F("Invalid method to /settings/apconfig/." CR));
+        request->send(405, F("text/plain"), F("Method not allowed."));
+    });
+
+    server.on("/settings/fermentracktarget/", HTTP_POST, [](AsyncWebServerRequest *request) {
+        Log.verbose(F("Processing post to /settings/fermentracktarget/." CR));
+        if (handleFermentrackPost(request))
+        {
+            request->send(200, F("text/plain"), F("Ok"));
+        }
+        else
+        {
+            request->send(500, F("text/plain"), F("Unable to process data"));
+        }
+    });
+
+    server.on("/settings/fermentracktarget/", HTTP_ANY, [](AsyncWebServerRequest *request) {
+        Log.verbose(F("Invalid method to /settings/fermentracktarget/." CR));
+        request->send(405, F("text/plain"), F("Method not allowed."));
+    });
+
+    server.on("/settings/bierbottarget/", HTTP_POST, [](AsyncWebServerRequest *request) {
+        Log.verbose(F("Processing post to /settings/bierbottarget/." CR));
+        if (handleBierBotPost(request))
+        {
+            request->send(200, F("text/plain"), F("Ok"));
+        }
+        else
+        {
+            request->send(500, F("text/plain"), F("Unable to process data"));
+        }
+    });
+
+    server.on("/settings/bierbottarget/", HTTP_ANY, [](AsyncWebServerRequest *request) {
+        Log.verbose(F("Invalid method to /settings/bierbottarget/." CR));
+        request->send(405, F("text/plain"), F("Method not allowed."));
+    });
+
 }
 bool handleURLTargetPost(AsyncWebServerRequest *request) // Handle URL Target Post
 {
@@ -476,7 +527,7 @@ bool handleiSpindHubPost(AsyncWebServerRequest *request) // Handle controller se
             }
             if (strcmp(name, "ispindhubTZ") == 0) // Set iSpindHub TimeZone
             {
-                if ((strlen(value) < 3) || (strlen(value) > 5))
+                if ((strlen(value) < 3) || (strlen(value) > 32))
                 {
                     Log.warning(F("Settings update error, [%s]:(%s) not valid." CR), name, value);
                 }
@@ -485,6 +536,18 @@ bool handleiSpindHubPost(AsyncWebServerRequest *request) // Handle controller se
                     strlcpy(config.ispindhub.TZ, value, sizeof(config.ispindhub.TZ));
                     Log.notice(F("Settings update, [%s]:(%s) applied." CR), name, value);
                     //ESP.restart();
+                }
+            }
+            if (strcmp(name, "ispindhubDST") == 0) // Set iSpindHub DST offset
+            {
+                if ((atoi(value) < 0) || (atoi(value) > 2))
+                {
+                    Log.warning(F("Settings update error, [%s]:(%s) not valid." CR), name, value);
+                }
+                else
+                {
+                    config.ispindhub.dst_offset = atoi(value);
+                    Log.notice(F("Settings update, [%s]:(%s) applied." CR), name, value);
                 }
             }
         }
@@ -617,6 +680,176 @@ bool handleBPiLessPost(AsyncWebServerRequest *request) // Handle URL Target Post
     else
     {
         Log.error(F("Error: Unable to save BPiless configuration data." CR));
+        return false;
+    }
+}
+
+bool handleApConfigPost(AsyncWebServerRequest *request) // Handle AP Config Post
+{
+    // Loop through all parameters
+    int params = request->params();
+    for (int i = 0; i < params; i++)
+    {
+        AsyncWebParameter *p = request->getParam(i);
+        if (p->isPost())
+        {
+            // Process any p->name().c_str() / p->value().c_str() pairs
+            const char *name = p->name().c_str();
+            const char *value = p->value().c_str();
+            Log.verbose(F("Processing [%s]:(%s) pair." CR), name, value);
+
+            if (strcmp(name, "apssid") == 0) // Change AP SSID
+            {
+                if ((strlen(value) < 3) || (strlen(value) > 32))
+                {
+                    Log.warning(F("Settings update error, [%s]:(%s) not applied." CR), name, value);
+                }
+                else
+                {
+                    Log.notice(F("Settings update, [%s]:(%s) applied." CR), name, value);
+                    strlcpy(config.apconfig.ssid, value, sizeof(config.apconfig.ssid));
+                }
+            }
+            if (strcmp(name, "appassphrase") == 0) // Change AP passphrase
+            {
+                if (strlen(value) == 0)
+                {
+                    Log.notice(F("Settings update, [%s]:(%s) applied. Open AP." CR), name, value);
+                    strlcpy(config.apconfig.passphrase, value, sizeof(config.apconfig.passphrase));
+                }
+                else if ((strlen(value) < 8) || (strlen(value) > 63))
+                {
+                    Log.warning(F("Settings update error, [%s]:(%s) not applied." CR), name, value);
+                }
+                else
+                {
+                    Log.notice(F("Settings update, [%s]:(%s) applied." CR), name, value);
+                    strlcpy(config.apconfig.passphrase, value, sizeof(config.apconfig.passphrase));
+                }
+            }
+        }
+    }
+    if (saveConfig())
+    {
+        return true;
+    }
+    else
+    {
+        Log.error(F("Error: Unable to save AP configuration data." CR));
+        return false;
+    }
+}
+
+bool handleFermentrackPost(AsyncWebServerRequest *request) // Handle Fermentrack Target Post
+{
+    // Loop through all parameters
+    int params = request->params();
+    for (int i = 0; i < params; i++)
+    {
+        AsyncWebParameter *p = request->getParam(i);
+        if (p->isPost())
+        {
+            // Process any p->name().c_str() / p->value().c_str() pairs
+            const char *name = p->name().c_str();
+            const char *value = p->value().c_str();
+            Log.verbose(F("Processing [%s]:(%s) pair." CR), name, value);
+
+            if (strcmp(name, "fermentrackurl") == 0) // Change Fermentrack URL
+            {
+                if (strlen(value) == 0)
+                {
+                    Log.notice(F("Settings update, [%s]:(%s) applied. Disabling Fermentrack target." CR), name, value);
+                    strlcpy(config.fermentrack.url, value, sizeof(config.fermentrack.url));
+                }
+                else if ((strlen(value) < 3) || (strlen(value) > 128))
+                {
+                    Log.warning(F("Settings update error, [%s]:(%s) not applied." CR), name, value);
+                }
+                else
+                {
+                    Log.notice(F("Settings update, [%s]:(%s) applied." CR), name, value);
+                    strlcpy(config.fermentrack.url, value, sizeof(config.fermentrack.url));
+                }
+            }
+            if (strcmp(name, "fermentrackfreq") == 0) // Change Fermentrack frequency
+            {
+                if ((atoi(value) < 1) || (atoi(value) > 60))
+                {
+                    Log.warning(F("Settings update error, [%s]:(%s) not applied." CR), name, value);
+                }
+                else
+                {
+                    Log.notice(F("Settings update, [%s]:(%s) applied." CR), name, value);
+                    config.fermentrack.freq = atoi(value);
+                    config.fermentrack.update = true;
+                }
+            }
+        }
+    }
+    if (saveConfig())
+    {
+        return true;
+    }
+    else
+    {
+        Log.error(F("Error: Unable to save Fermentrack configuration data." CR));
+        return false;
+    }
+}
+
+bool handleBierBotPost(AsyncWebServerRequest *request) // Handle BierBot Target Post
+{
+    // Loop through all parameters
+    int params = request->params();
+    for (int i = 0; i < params; i++)
+    {
+        AsyncWebParameter *p = request->getParam(i);
+        if (p->isPost())
+        {
+            // Process any p->name().c_str() / p->value().c_str() pairs
+            const char *name = p->name().c_str();
+            const char *value = p->value().c_str();
+            Log.verbose(F("Processing [%s]:(%s) pair." CR), name, value);
+
+            if (strcmp(name, "bierbotkey") == 0) // Change BierBot key
+            {
+                if (strlen(value) == 0)
+                {
+                    Log.notice(F("Settings update, [%s]:(%s) applied. Disabling BierBot target." CR), name, value);
+                    strlcpy(config.bierbot.key, value, sizeof(config.bierbot.key));
+                }
+                else if ((strlen(value) < 10) || (strlen(value) > 64))
+                {
+                    Log.warning(F("Settings update error, [%s]:(%s) not applied." CR), name, value);
+                }
+                else
+                {
+                    Log.notice(F("Settings update, [%s]:(%s) applied." CR), name, value);
+                    strlcpy(config.bierbot.key, value, sizeof(config.bierbot.key));
+                }
+            }
+            if (strcmp(name, "bierbotfreq") == 0) // Change BierBot frequency
+            {
+                if ((atoi(value) < 2) || (atoi(value) > 120))
+                {
+                    Log.warning(F("Settings update error, [%s]:(%s) not applied." CR), name, value);
+                }
+                else
+                {
+                    Log.notice(F("Settings update, [%s]:(%s) applied." CR), name, value);
+                    config.bierbot.freq = atoi(value);
+                    config.bierbot.update = true;
+                }
+            }
+        }
+    }
+    if (saveConfig())
+    {
+        return true;
+    }
+    else
+    {
+        Log.error(F("Error: Unable to save BierBot configuration data." CR));
         return false;
     }
 }

--- a/src/web.h
+++ b/src/web.h
@@ -29,6 +29,9 @@ bool handleiSpindHubPost(AsyncWebServerRequest *request);
 bool handleURLTargetPost(AsyncWebServerRequest *request);
 bool handleBrewfatherTargetPost(AsyncWebServerRequest *request);
 bool handleBPiLessPost(AsyncWebServerRequest *request);
+bool handleApConfigPost(AsyncWebServerRequest *request);
+bool handleFermentrackPost(AsyncWebServerRequest *request);
+bool handleBierBotPost(AsyncWebServerRequest *request);
 
 #define LOG_LEVEL LOG_LEVEL_VERBOSE
 extern struct Config config;

--- a/src/wifi.cpp
+++ b/src/wifi.cpp
@@ -80,7 +80,7 @@ void doWiFi(bool dontUseStoredCreds)
                 Log.notice(F(HOSTNAME CR));
                 // WiFi.setHostname(HOSTNAME);
                 WiFi.hostname(HOSTNAME);
-                WiFi.softAP(HOSTNAME);
+                WiFi.softAP(HOSTNAME, config.apconfig.passphrase);
             }
             else
             {
@@ -89,7 +89,7 @@ void doWiFi(bool dontUseStoredCreds)
                 Log.notice(config.ispindhub.name);
                 Log.notice(F(CR));
                 WiFi.hostname(config.ispindhub.name);
-                WiFi.softAP(config.ispindhub.name);
+                WiFi.softAP(config.ispindhub.name, config.apconfig.passphrase);
             }
 
             Log.notice(F("Get Out Set HostName" CR));
@@ -168,11 +168,11 @@ void WiFiEvent(WiFiEvent_t event)
             bool isdeployed;
             if (strlen(config.ispindhub.name) == 0)
             {
-                isdeployed = WiFi.softAP(APNAME);
+                isdeployed = WiFi.softAP(APNAME, config.apconfig.passphrase);
             }
             else
             {
-                isdeployed = WiFi.softAP(config.ispindhub.name);
+                isdeployed = WiFi.softAP(config.ispindhub.name, config.apconfig.passphrase);
             }
 
             if (!isdeployed)


### PR DESCRIPTION
## Summary

- **#13 — Hello World on root**: `setActionPageHandlers()` was registering an explicit `server.on("/")` handler that returned plain text `"Hello World"`, which overrode the `serveStatic` set up in `setRegPageAliases()`. Removed the dead handler — the static file server now serves `index.htm` as intended.
- **#12 — Version mismatch / dead code**: Bumped `PIO_SRC_TAG` from `0.0.7` to `0.0.9` to match the latest release. Removed commented-out code left over from the old Adafruit/ST7735 driver (`Serial.println` calls, old JSON capacity constants, unused `float data_size` cast). Also fixes the `data_size` type from `float` to `int` — it was being used as a field count.
- **#9 — ILI9341 white screen / build failures**: Pinned `TFT_eSPI` to `2.5.43` (the `^2.3.67` range was pulling in breaking changes). Added the two flags that most ILI9341 panels need but were missing from the `2_4_inches_ILI9341` env: `TFT_RGB_ORDER=TFT_BGR` and `TFT_INVERSION_ON=1`. If your specific panel *doesn't* need inversion, removing `TFT_INVERSION_ON=1` will flip it back.

## Test plan

- [ ] Flash the `2_4_inches_ILI9341` env and confirm display shows data (not a white screen)
- [ ] Open the hub's IP in a browser — should load the dashboard, not "Hello World"
- [ ] Check `/thisVersion/` returns `0.0.9`
- [ ] Confirm all other display envs (ST7735, ILI9225) still build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)