### PR TITLE
Fix WDT crash from missing template file and blocking iSpindInfo handler

### DIFF
--- a/src/ispindel.cpp
+++ b/src/ispindel.cpp
@@ -25,7 +25,6 @@ int handle_spindel_data(String iSpinData,int delay_loop,int last_seen_ms){
     }
     //Serial.println("delay loop en sortant");
     //Serial.println(delay_loop);
-    wdt_disable();
     String screen_template = "korev";
     parse_screen_template(screen_template,array_data,last_seen_ms);
     //delay(5000);

--- a/src/templatescreen.cpp
+++ b/src/templatescreen.cpp
@@ -25,17 +25,21 @@ void parse_screen_template(String screen_template, String array_data[10], int la
     String fname = String("/data/templates/") + String(screen_template) + String(".json");
 
     File file = LittleFS.open(fname, "r");
+    if (!file || file.size() == 0)
+    {
+        Serial.println(F("Template file missing or empty, skipping display update."));
+        wdt_enable(WDTO_8S);
+        return;
+    }
     String parsingScreen = file.readString();
+    file.close();
     JsonDocument parsedScreen;
-    // ReadLoggingStream loggingStream(parsingScreen, Serial);
-    // ReadLoggingStream loggingStream(file, Serial);
-    // DeserializationError errPars = deserializeJson(parsedScreen, loggingStream);
-    // DeserializationError errPars = deserializeJson(parsedScreen,file);
     DeserializationError errPars = deserializeJson(parsedScreen, parsingScreen);
     if (errPars)
     {
         Serial.print(F("deserializeJson() for template failed: "));
         Serial.println(errPars.f_str());
+        wdt_enable(WDTO_8S);
         return;
     }
     else

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -121,20 +121,23 @@ void setJsonHandlers()
         Dir dir = LittleFS.openDir("/data");
         String file_info = "{";
         while (dir.next()) {
-            //Porcessing One file at at time
+            yield(); // feed hardware WDT between files
             String f_name = dir.fileName();
             if(dir.fileSize()) {
                 File file = dir.openFile("r");
                 time_t cr = file.getCreationTime();
-                //Serial.println(cr);
                 time_t lw = file.getLastWrite();
-                //Serial.println(lw);
                 //Get Last Readings
                 String temp = file.readStringUntil('\r');
-                int line_len = temp.length()+1;
+                int line_len = temp.length() + 1;
                 int file_size = file.size();
-                float num_line = file_size/line_len;
-                file.seek(line_len,SeekEnd);
+                if (line_len <= 1 || file_size < line_len) {
+                    // File has no complete row yet — skip to avoid seek underflow
+                    file.close();
+                    continue;
+                }
+                float num_line = file_size / line_len;
+                file.seek(line_len, SeekEnd);
                 String lastData  = file.readString();
                 //String lastData = get_last_value(file.readString());
                 //Serial.println(iSpinData);


### PR DESCRIPTION
## Root cause

Two cooperating bugs caused the `rst cause:4` (hardware watchdog) crash.

### 1 — `templatescreen.cpp`: software WDT left permanently disabled

`parse_screen_template()` calls `wdt_disable()` at entry so that slow TFT rendering doesn't trip the watchdog. It re-enables via `wdt_enable(WDTO_8S)` at the bottom — but only on the *success* path. The early `return` on line 39 (template file missing/empty) exits the function before re-enabling, so the software WDT stays off for the rest of the session.

The template file `/data/templates/korev.json` doesn't ship in the `data/` folder, so *every* boot hits this path.

Also fixed: `file.readString()` was called on an unopened `File` object when the path didn't exist.

### 2 — `/iSpindInfo/` handler blocks the hardware WDT

With the software WDT dead, the `while (dir.next())` loop in the `/iSpindInfo/` GET handler runs without ever calling `yield()`. The ESP8266 hardware WDT fires unconditionally after ~6–8 s of uninterrupted CPU use regardless of `wdt_disable()`. With multiple iSpindel CSV files and the heavy `String +=` building inside, this threshold is easily crossed.

Bonus fix: if a CSV file has only one row and it doesn't end with `\r` yet, `line_len` equals the full file size, and `file.seek(line_len, SeekEnd)` underflows to a negative offset. Added a guard to skip such files.

## Changes

| File | Change |
|------|--------|
| `src/templatescreen.cpp` | Check file opens and has size > 0 before reading; call `wdt_enable(WDTO_8S)` on every early return path |
| `src/ispindel.cpp` | Remove duplicate `wdt_disable()` before `parse_screen_template()` — the function owns the WDT lifecycle |
| `src/web.cpp` | Add `yield()` at top of `dir.next()` loop; skip files where no complete row exists yet |

## Test plan
- [ ] Boot with no `/data/templates/korev.json` file on LittleFS — hub should start cleanly, no WDT crash
- [ ] With 2+ iSpindel devices reporting, call `/iSpindInfo/` — should return JSON without crashing
- [ ] Confirm Serial shows `"Template file missing or empty, skipping display update."` instead of a crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)