### PR TITLE
Fix panic: replace yield() with ESP.wdtFeed() in iSpindInfo handler

### DIFF
--- a/src/web.cpp
+++ b/src/web.cpp
@@ -121,7 +121,7 @@ void setJsonHandlers()
         Dir dir = LittleFS.openDir("/data");
         String file_info = "{";
         while (dir.next()) {
-            yield(); // feed hardware WDT between files
+            ESP.wdtFeed(); // ISR-safe WDT reset (yield() panics in TCP callback context)
             String f_name = dir.fileName();
             if(dir.fileSize()) {
                 File file = dir.openFile("r");


### PR DESCRIPTION
## Problem

`Panic core_esp8266_main.cpp:137 __yield` — `yield()` was called from interrupt context.

The `ctx: sys` in the stack trace shows the `/iSpindInfo/` GET handler is invoked from within the ESP8266 TCP/LwIP interrupt context by AsyncWebServer. Calling `yield()` from interrupt context is unconditionally fatal on ESP8266 — the runtime panics to prevent re-entrant event loop processing.

This was introduced in the previous WDT fix (PR #15) which added `yield()` to prevent the hardware WDT from firing.

## Fix

Replace `yield()` with `ESP.wdtFeed()` — one character change, different semantics:

- `yield()` — runs the event loop, **illegal in ISR context**
- `ESP.wdtFeed()` — calls `ets_wdt_reset()` directly, **ISR-safe**, resets the software WDT counter without entering the event loop

With the template WDT bug fixed (PR #15), the software WDT is now properly managed throughout the main loop. `ESP.wdtFeed()` between file iterations is sufficient to prevent a WDT timeout during `/iSpindInfo/` processing.

## Test plan
- [ ] Call `/iSpindInfo/` with multiple iSpindel CSV files present — no panic, returns JSON
- [ ] Confirm no `Panic __yield` in serial output

🤖 Generated with [Claude Code](https://claude.com/claude-code)