### PR TITLE
Remove WDT feed from iSpindInfo handler (both yield and wdtFeed panic in ISR)

### DIFF
--- a/src/web.cpp
+++ b/src/web.cpp
@@ -121,7 +121,6 @@ void setJsonHandlers()
         Dir dir = LittleFS.openDir("/data");
         String file_info = "{";
         while (dir.next()) {
-            ESP.wdtFeed(); // ISR-safe WDT reset (yield() panics in TCP callback context)
             String f_name = dir.fileName();
             if(dir.fileSize()) {
                 File file = dir.openFile("r");


### PR DESCRIPTION
## Problem

`ESP.wdtFeed()` was added to prevent hardware WDT timeouts in the `/iSpindInfo/` handler (PR #16). It still causes `Panic core_esp8266_main.cpp:137 __yield` because in ESP8266 Arduino, `ESP.wdtFeed()` is implemented as `esp_yield()`, which is an alias for `__yield()`. `__yield()` panics unconditionally when called from `ctx: sys` (the LwIP TCP interrupt context that AsyncWebServer handlers run in).

There is no yield-free WDT feed available from interrupt context in ESP8266 Arduino.

## Fix

Remove the call entirely. The handler doesn't need it:

- The original WDT crash (PR #15) was caused by the **missing template file** leaving `wdt_disable()` called without a matching `wdt_enable()`, permanently disabling the software WDT for the whole session. That is now fixed.
- With the software WDT properly managed, the `/iSpindInfo/` handler completes in well under the 3.2 s soft WDT window for typical 1–3 iSpindel usage.

## Test plan
- [ ] Call `/iSpindInfo/` — no panic, returns JSON
- [ ] Serial shows no `__yield` panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)