### PR TITLE
Add template selection and upload to settings

### DIFF
--- a/data/settings.htm
+++ b/data/settings.htm
@@ -130,6 +130,12 @@
             </li>
             <!-- Controller Nav Item -->
 
+            <!-- Display Nav Item -->
+            <li class="nav-item">
+              <a class="nav-link" data-toggle="tab" href="#display">Display</a>
+            </li>
+            <!-- Display Nav Item -->
+
             <!-- Targets Nav Item -->
             <li class="nav-item dropdown">
               <a
@@ -1078,6 +1084,86 @@
               </div>
             </div>
             <!-- BierBot Settings tab -->
+
+            <!-- Display Settings tab -->
+            <div class="tab-pane fade" id="display">
+              <div class="card-header">
+                <h4 class="card-title">Display Settings</h4>
+              </div>
+              <div class="card-body">
+                <ul class="list-group list-group-flush">
+                  <li class="list-group-item">
+                    <p class="card-text">
+                      Choose which template to use for the TFT screen display.
+                      Templates are JSON files stored in
+                      <code>/data/templates/</code> on the device.
+                    </p>
+
+                    <form
+                      class="form-group"
+                      id="display"
+                      action="/settings/template/"
+                      method="POST"
+                      onsubmit="return processPost(this);"
+                    >
+                      <div class="form-group row">
+                        <label
+                          for="screentemplate"
+                          class="col-sm-3 col-form-label"
+                          data-toggle="tooltip"
+                          title="Select the active display template"
+                        >
+                          Active Template
+                        </label>
+                        <div class="col-sm-9">
+                          <select
+                            class="form-control"
+                            id="screentemplate"
+                            name="screentemplate"
+                          >
+                            <!-- Populated by loadTemplates() -->
+                          </select>
+                        </div>
+                      </div>
+                      <div class="row col-sm-12 justify-content-center">
+                        <button
+                          class="btn btn-primary"
+                          id="submitSettings"
+                          onclick="if(!this.form.checkValidity(this)){return (false);}"
+                        >
+                          Update
+                        </button>
+                      </div>
+                    </form>
+
+                    <hr />
+                    <p class="card-text">
+                      Upload a new template JSON file to the device:
+                    </p>
+                    <div class="form-group row">
+                      <label class="col-sm-3 col-form-label">Template File</label>
+                      <div class="col-sm-9">
+                        <input
+                          type="file"
+                          class="form-control-file"
+                          id="templatefile"
+                          accept=".json"
+                        />
+                      </div>
+                    </div>
+                    <div class="row col-sm-12 justify-content-center">
+                      <button
+                        class="btn btn-secondary"
+                        onclick="uploadTemplate(); return false;"
+                      >
+                        Upload
+                      </button>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <!-- Display Settings tab -->
 
           </div>
           <!-- Nav Tab Content -->

--- a/data/settings.js
+++ b/data/settings.js
@@ -102,6 +102,7 @@ function populateForm() { // Get current parameters
                 $('#fermentrackfreq').val(config.fermentrack.freq);
                 $('#bierbotkey').val(config.bierbot.key);
                 $('#bierbotfreq').val(config.bierbot.freq);
+                loadTemplates(config.ispindhub.screen_template || 'korev');
             } catch {
                 if (!unloadingState) {
                     alert("Unable to parse configuration data.");
@@ -116,6 +117,52 @@ function populateForm() { // Get current parameters
         .always(function() {
             // Can post-process here
         });
+}
+
+function loadTemplates(selected) { // Populate template dropdown from device
+    $.getJSON('/templates/', function() {})
+        .done(function(templates) {
+            var $sel = $('#screentemplate');
+            $sel.empty();
+            for (var i = 0; i < templates.length; i++) {
+                var opt = $('<option></option>').val(templates[i]).text(templates[i]);
+                if (templates[i] === selected) opt.attr('selected', true);
+                $sel.append(opt);
+            }
+            if (templates.length === 0) {
+                $sel.append('<option value="">No templates found</option>');
+            }
+        })
+        .fail(function() {
+            if (!unloadingState) {
+                $('#screentemplate').append('<option value="">Error loading templates</option>');
+            }
+        });
+}
+
+function uploadTemplate() { // Upload a new template JSON file to the device
+    var input = document.getElementById('templatefile');
+    if (!input.files || !input.files.length) {
+        alert("Please select a .json file to upload.");
+        return;
+    }
+    var formData = new FormData();
+    formData.append('file', input.files[0]);
+    $.ajax({
+        url: '/templates/upload/',
+        type: 'POST',
+        data: formData,
+        processData: false,
+        contentType: false,
+        success: function() {
+            input.value = '';
+            loadTemplates($('#screentemplate').val());
+            alert("Template uploaded successfully.");
+        },
+        error: function() {
+            alert("Template upload failed.");
+        }
+    });
 }
 
 
@@ -172,6 +219,9 @@ function processPost(obj) {
             break;
         case "#bierbot":
             processBierBotPost(url, obj);
+            break;
+        case "#display":
+            processTemplatePost(url, obj);
             break;
         default:
             // Unknown hash location passed
@@ -320,6 +370,14 @@ function processFermentrackPost(url, obj) {
         fermentrackurl: fermentrackurl,
         fermentrackfreq: fermentrackfreq
     };
+    postData(url, data);
+}
+
+function processTemplatePost(url, obj) {
+    // Handle display template selection posts
+    var $form = $(obj),
+        screentemplate = $form.find("select[name='screentemplate']").val();
+    data = { screentemplate: screentemplate };
     postData(url, data);
 }
 

--- a/src/ispindel.cpp
+++ b/src/ispindel.cpp
@@ -1,4 +1,5 @@
 #include "ispindel.h"
+#include "jsonconfig.h"
 //extern Adafruit_ST7735 tft;
 extern TFT_eSPI tft;
 //extern int delay_loop;
@@ -25,7 +26,8 @@ int handle_spindel_data(String iSpinData,int delay_loop,int last_seen_ms){
     }
     //Serial.println("delay loop en sortant");
     //Serial.println(delay_loop);
-    String screen_template = "korev";
+    String screen_template = String(config.ispindhub.screen_template);
+    if (screen_template.length() == 0) screen_template = "korev";
     parse_screen_template(screen_template,array_data,last_seen_ms);
     //delay(5000);
     //displaydata(array_data,last_seen_ms);

--- a/src/jsonconfig.cpp
+++ b/src/jsonconfig.cpp
@@ -345,6 +345,7 @@ void iSpindHub::save(JsonObject obj) const
     obj["name"] = name;
     obj["TZ"] = TZ;
     obj["dst_offset"] = dst_offset;
+    obj["screen_template"] = screen_template;
 }
 
 void iSpindHub::load(JsonObjectConst obj)
@@ -380,6 +381,16 @@ void iSpindHub::load(JsonObjectConst obj)
     {
         int d = obj["dst_offset"];
         dst_offset = d;
+    }
+
+    if (obj["screen_template"].isNull())
+    {
+        strlcpy(screen_template, "korev", sizeof(screen_template));
+    }
+    else
+    {
+        const char *st = obj["screen_template"];
+        strlcpy(screen_template, st, sizeof(screen_template));
     }
 }
 

--- a/src/jsonconfig.h
+++ b/src/jsonconfig.h
@@ -14,6 +14,7 @@ struct iSpindHub
     char name[32];
     char TZ[32];
     int dst_offset;
+    char screen_template[32];
     void load(JsonObjectConst);
     void save(JsonObject) const;
 };

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -195,6 +195,24 @@ void setJsonHandlers()
     });
     // JSON Handlers
 
+    server.on("/templates/", HTTP_GET, [](AsyncWebServerRequest *request) {
+        // List available screen templates (filenames without .json extension)
+        String json = "[";
+        bool first = true;
+        Dir dir = LittleFS.openDir("/data/templates");
+        while (dir.next()) {
+            String fn = dir.fileName();
+            if (fn.endsWith(".json")) {
+                if (!first) json += ",";
+                fn.remove(fn.length() - 5);
+                json += "\"" + fn + "\"";
+                first = false;
+            }
+        }
+        json += "]";
+        request->send(200, F("application/json"), json);
+    });
+
     server.on("/resetreason/", HTTP_GET, [](AsyncWebServerRequest *request) {
         // Used to provide the reset reason json
         Log.verbose(F("Sending /resetreason/." CR));
@@ -434,6 +452,30 @@ void setSettingsAliases()
         Log.verbose(F("Invalid method to /settings/bierbottarget/." CR));
         request->send(405, F("text/plain"), F("Method not allowed."));
     });
+
+    server.on("/settings/template/", HTTP_POST, [](AsyncWebServerRequest *request) {
+        Log.verbose(F("Processing post to /settings/template/." CR));
+        if (handleTemplatePost(request))
+        {
+            request->send(200, F("text/plain"), F("Ok"));
+        }
+        else
+        {
+            request->send(500, F("text/plain"), F("Unable to process data"));
+        }
+    });
+
+    server.on("/settings/template/", HTTP_ANY, [](AsyncWebServerRequest *request) {
+        Log.verbose(F("Invalid method to /settings/template/." CR));
+        request->send(405, F("text/plain"), F("Method not allowed."));
+    });
+
+    server.on("/templates/upload/", HTTP_POST,
+        [](AsyncWebServerRequest *request) {
+            request->send(200, F("text/plain"), F("Ok"));
+        },
+        handleTemplateUpload
+    );
 
 }
 bool handleURLTargetPost(AsyncWebServerRequest *request) // Handle URL Target Post
@@ -849,6 +891,62 @@ bool handleBierBotPost(AsyncWebServerRequest *request) // Handle BierBot Target 
     {
         Log.error(F("Error: Unable to save BierBot configuration data." CR));
         return false;
+    }
+}
+
+bool handleTemplatePost(AsyncWebServerRequest *request)
+{
+    int params = request->params();
+    for (int i = 0; i < params; i++)
+    {
+        AsyncWebParameter *p = request->getParam(i);
+        if (p->isPost())
+        {
+            const char *name = p->name().c_str();
+            const char *value = p->value().c_str();
+            Log.verbose(F("Processing [%s]:(%s) pair." CR), name, value);
+            if (strcmp(name, "screentemplate") == 0)
+            {
+                if (strlen(value) > 0 && strlen(value) <= 31)
+                {
+                    strlcpy(config.ispindhub.screen_template, value, sizeof(config.ispindhub.screen_template));
+                    Log.notice(F("Settings update, screen template set to: %s" CR), value);
+                }
+            }
+        }
+    }
+    if (saveConfig())
+    {
+        return true;
+    }
+    else
+    {
+        Log.error(F("Error: Unable to save template configuration data." CR));
+        return false;
+    }
+}
+
+static File s_templateUpload;
+
+void handleTemplateUpload(AsyncWebServerRequest *request, const String& filename, size_t index, uint8_t *data, size_t len, bool final)
+{
+    if (index == 0)
+    {
+        String fn = filename;
+        int sep = fn.lastIndexOf('/');
+        if (sep >= 0) fn = fn.substring(sep + 1);
+        if (!fn.endsWith(".json")) fn += ".json";
+        Log.verbose(F("Template upload start: %s" CR), fn.c_str());
+        s_templateUpload = LittleFS.open("/data/templates/" + fn, "w");
+    }
+    if (s_templateUpload)
+    {
+        s_templateUpload.write(data, len);
+    }
+    if (final && s_templateUpload)
+    {
+        Log.verbose(F("Template upload complete." CR));
+        s_templateUpload.close();
     }
 }
 

--- a/src/web.h
+++ b/src/web.h
@@ -32,6 +32,8 @@ bool handleBPiLessPost(AsyncWebServerRequest *request);
 bool handleApConfigPost(AsyncWebServerRequest *request);
 bool handleFermentrackPost(AsyncWebServerRequest *request);
 bool handleBierBotPost(AsyncWebServerRequest *request);
+bool handleTemplatePost(AsyncWebServerRequest *request);
+void handleTemplateUpload(AsyncWebServerRequest *request, const String& filename, size_t index, uint8_t *data, size_t len, bool final);
 
 #define LOG_LEVEL LOG_LEVEL_VERBOSE
 extern struct Config config;


### PR DESCRIPTION
## Summary

- **Template selection** — active display template is now stored in config (`ispindhub.screen_template`, default `"korev"`). `ispindel.cpp` reads from config instead of the hardcoded string.
- **Template listing** — `GET /templates/` returns a JSON array of template names found in `/data/templates/` (filenames without `.json` extension).
- **Template upload** — `POST /templates/upload/` accepts a multipart file upload and writes it to `/data/templates/<filename>.json` on LittleFS.
- **Settings UI** — new **Display** tab in Settings with:
  - A dropdown pre-populated from `/templates/` with the current selection highlighted
  - A file picker + Upload button that POSTs to `/templates/upload/` via `FormData` AJAX and refreshes the dropdown on success

## Files changed
| File | Change |
|---|---|
| `src/jsonconfig.h` | Add `char screen_template[32]` to `iSpindHub` |
| `src/jsonconfig.cpp` | Save/load `screen_template` (default `"korev"`) |
| `src/ispindel.cpp` | Use `config.ispindhub.screen_template`; include `jsonconfig.h` |
| `src/web.h` | Declare `handleTemplatePost` and `handleTemplateUpload` |
| `src/web.cpp` | Add `/templates/` list handler, `/settings/template/` POST handler, `/templates/upload/` upload handler + implementation functions |
| `data/settings.htm` | Add Display tab nav item + tab pane (select + upload form) |
| `data/settings.js` | `loadTemplates()`, `processTemplatePost()`, `uploadTemplate()`; hook into `populateForm()` and `processPost()` switch |

## Test plan
- [ ] Build and flash (`pio run -e <env> -t upload`)
- [ ] Upload filesystem (`pio run -e <env> -t uploadfs`)
- [ ] Open Settings → Display tab: dropdown shows `korev` (and any other templates)
- [ ] Select a template and click Update: screen switches to that template on next iSpindel data receive
- [ ] Upload a new `.json` template file: appears in dropdown immediately
- [ ] Verify config persists after reboot (template stays selected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)