### PR TITLE
Ignore bundled AsyncWebServer from ESPAsync_WiFiManager

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,6 +35,7 @@ lib_deps =
 	arkhipenko/Dictionary @ ^3.5.0
 	khoih-prog/ESPAsync_WiFiManager
 lib_ldf_mode = chain
+lib_ignore = ESP Async WebServer
 board_build.filesystem = littlefs
 build_flags = 
 	-DPIO_SRC_TAG="0.0.9"


### PR DESCRIPTION
## Summary

Add `lib_ignore = ESP Async WebServer` to the base `[env]` section.

`khoih-prog/ESPAsync_WiFiManager` vendors its own copy of ESPAsyncWebServer, which conflicts with the explicitly declared `esphome/ESPAsyncWebServer` dependency. `lib_ignore` tells PlatformIO to skip the bundled copy so only one implementation is compiled.

## Test plan
- [ ] `pio run -e <any env>` — build completes without duplicate-symbol errors
- [ ] WiFiManager portal still works at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)