### PR TITLE
Fix 404 on API endpoints without trailing slash; fix NTP log format

### DIFF
--- a/src/ntp.cpp
+++ b/src/ntp.cpp
@@ -52,7 +52,7 @@ void setClock() {
       TMZ = "CET";
     }
     Serial.println(TMZ);
-    Log.notice("Time Zone used is %", TMZ);
+    Log.notice(F("Time Zone used is %s" CR), TMZ);
     configTime(tzToOffsetSeconds(TMZ), (long)config.ispindhub.dst_offset * 3600, "pool.ntp.org", "time.nist.gov");
     time_t nowSecs = time(nullptr);
     time_t startSecs = time(nullptr);

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -193,7 +193,17 @@ void setJsonHandlers()
         file_info+= "}";
         request->send(200, F("application/json"), file_info);
     });
-    // JSON Handlers
+    // JSON Handlers — redirect bare paths (no trailing slash) to canonical form
+    auto slashRedirect = [](AsyncWebServerRequest *request) {
+        request->redirect(request->url() + "/");
+    };
+    server.on("/thisVersion",  HTTP_GET, slashRedirect);
+    server.on("/config",       HTTP_GET, slashRedirect);
+    server.on("/uptime",       HTTP_GET, slashRedirect);
+    server.on("/heap",         HTTP_GET, slashRedirect);
+    server.on("/resetreason",  HTTP_GET, slashRedirect);
+    server.on("/templates",    HTTP_GET, slashRedirect);
+    server.on("/iSpindInfo",   HTTP_GET, slashRedirect);
 
     server.on("/templates/", HTTP_GET, [](AsyncWebServerRequest *request) {
         // List available screen templates (filenames without .json extension)


### PR DESCRIPTION
## Summary

**404 on bare paths** — All JSON handlers are registered as `/path/` (trailing slash). Requesting `/path` (no slash) falls through to `serveStatic`, which finds no file and returns 404. A shared `slashRedirect` lambda now issues a `302` → `/path/` for all seven JSON endpoints: `/thisVersion`, `/config`, `/uptime`, `/heap`, `/resetreason`, `/templates`, `/iSpindInfo`.

**NTP log garbled** — `Log.notice("Time Zone used is %", TMZ)` used a bare `%` with no format specifier. ArduinoLog consumed `TMZ` as a format character and printed the next value off the stack (which happened to be the NTP server string `"time.nist.gov"`). Fixed to `Log.notice(F("Time Zone used is %s" CR), TMZ)`.

## Test plan
- [ ] `http://<hub>/thisVersion` → redirects to `/thisVersion/` → returns version JSON
- [ ] Same for `/config`, `/uptime`, `/heap`, `/resetreason`
- [ ] Serial monitor shows correct timezone on boot: `Time Zone used is CET` (or whatever is configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)