### PR TITLE
Fix HTTP 500, WiFi credential crash, and silent push timers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,6 +140,8 @@ void loop()
   // put your main code here, to run repeatedly:
   Serial.println("Début du Loop");
   BFa_timer.update();
+  FT_timer.update();
+  BB_timer.update();
   FSInfo fs_info;
   LittleFS.info(fs_info);
   Dir dir = LittleFS.openDir("/data");

--- a/src/wifi.cpp
+++ b/src/wifi.cpp
@@ -1,12 +1,13 @@
 #include "wifi.h"
 bool shouldSaveConfig = false;
 const byte DNS_PORT = 53;
-#define HTTP_PORT 80
 IPAddress apIP(192, 168, 4, 1);
-AsyncWebServer webServer(HTTP_PORT);
 AsyncDNSServer dnsServer;
 
-ESPAsync_WiFiManager wm(&webServer, &dnsServer, "iSpindHub");
+// Use the single AsyncWebServer instance from web.cpp to avoid having two
+// listeners on port 80 (which causes HTTP 500 on all our routes).
+extern AsyncWebServer server;
+ESPAsync_WiFiManager wm(&server, &dnsServer, "iSpindHub");
 
 void doWiFi()
 {
@@ -65,6 +66,17 @@ void doWiFi(bool dontUseStoredCreds)
         // blinker.attach_ms(STABLINK, wifiBlinker);
         wm.setConnectTimeout(30);
         wm.setConfigPortalTimeout(120);
+        // Disconnect any stale association first.
+        WiFi.disconnect(false);
+        // ESPAsync_WiFiManager v1.15.1 crashes (Exception 28) when the stored
+        // WiFi password is shorter than WPA minimum (8 chars) instead of
+        // falling back to the config portal.  Pre-check here and erase bad
+        // credentials so autoConnect opens a fresh portal instead of crashing.
+        if (!WiFi.SSID().isEmpty() && WiFi.psk().length() > 0 && WiFi.psk().length() < 8) {
+            Log.warning(F("Stored WiFi password too short (%d chars) — clearing to prevent WiFiManager crash." CR),
+                        (int)WiFi.psk().length());
+            WiFi.disconnect(true); // erase stored SSID/PSK
+        }
         if (!wm.autoConnect(APNAME, APPWD))
         {
             Log.warning(F("Failed to connect and/or hit timeout." CR));


### PR DESCRIPTION
## Summary

- **HTTP 500 on every page** — `wifi.cpp` declared its own `AsyncWebServer webServer(80)` for WiFiManager while `web.cpp` had `AsyncWebServer server(80)` for the app. WiFiManager's server bound port 80 first; our server's `begin()` silently failed. Every incoming request went to the empty WiFiManager server → HTTP 500. Fixed by removing `webServer` and passing `server` (from `web.cpp` via `extern`) to `ESPAsync_WiFiManager`.

- **WiFi credentials appeared not to save** — they were being written to ESP8266 SDK flash correctly, but the Exception 28 crash on the *next* boot (triggered when WiFiManager tried to validate the stored credentials) created an infinite crash-reboot loop. From the user's perspective: portal → enter credentials → "connected" → reboot → crash → portal again. Added a pre-check: if `WiFi.psk().length() < 8` (WPA minimum), erase the stored credentials before `autoConnect()` so the library opens a clean portal instead of crashing. Also calls `WiFi.disconnect()` first to clear any stale association state.

- **Fermentrack and BierBot push never fired** — `FT_timer` and `BB_timer` were started in `setup()` but their `update()` calls were missing from `loop()`. Only `BFa_timer.update()` was there. Added the two missing calls.

## Test plan

- [ ] Flash firmware + filesystem, power on fresh — device opens WiFiManager portal (no stored credentials)
- [ ] Enter WiFi credentials in portal — device connects, `http://<ip>/` loads the dashboard (not a 500)
- [ ] Reboot device — reconnects automatically, dashboard still loads
- [ ] Set Fermentrack/BierBot push intervals in settings — verify pushes actually fire after the configured interval
- [ ] Enter a short (<8 char) password in portal — device clears it on next boot and opens portal instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)