### PR TITLE
Fix build errors: missing config extern and t_format buffer

### DIFF
--- a/src/ispindel.cpp
+++ b/src/ispindel.cpp
@@ -2,6 +2,7 @@
 #include "jsonconfig.h"
 //extern Adafruit_ST7735 tft;
 extern TFT_eSPI tft;
+extern struct Config config;
 //extern int delay_loop;
 
 int handle_spindel_data(String iSpinData,int delay_loop,int last_seen_ms){

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -145,8 +145,8 @@ void setJsonHandlers()
                 file_info+= "\"" + f_name+ "\"";
                 file_info+= ": { \"created\":\"";
                 struct tm * tmstruct = localtime(&cr);
-                char t_format[32];
-                sprintf(t_format,"%d-%02d-%02d %02d:%02d:%02d", (tmstruct->tm_year) + 1900, (tmstruct->tm_mon) + 1, tmstruct->tm_mday, tmstruct->tm_hour, tmstruct->tm_min, tmstruct->tm_sec);
+                char t_format[64];
+                snprintf(t_format, sizeof(t_format), "%d-%02d-%02d %02d:%02d:%02d", (tmstruct->tm_year) + 1900, (tmstruct->tm_mon) + 1, tmstruct->tm_mday, tmstruct->tm_hour, tmstruct->tm_min, tmstruct->tm_sec);
                 //store creation date
                 file_info+=String(t_format);
                 tmstruct = localtime(&lw);


### PR DESCRIPTION
## Summary

Two build errors introduced when the template selection feature was added to `ispindel.cpp`:

- **`ispindel.cpp` — `config` not declared in scope**: `ispindel.cpp` includes `jsonconfig.h` (which defines the `Config` struct) but the actual `config` instance lives in `jsonconfig.cpp` and is exported via `extern` in `wifi.h`. Since `ispindel.cpp` doesn't include `wifi.h`, the extern was missing. Fixed by adding `extern struct Config config;` directly in `ispindel.cpp`.

- **`web.cpp` — `-Wformat-overflow` on `t_format[32]`**: `sprintf(t_format, "%d-%02d-...", tm_year+1900, ...)` — the compiler correctly notes that `%d` has no compile-time upper bound, so worst-case output exceeds the 32-byte buffer. In practice the timestamp is always 19 chars, but using `snprintf` with a 64-byte buffer is the right fix.

## Test plan

- [ ] Build succeeds for all environments with no errors
- [ ] iSpindel data still displays using the correct template from config

🤖 Generated with [Claude Code](https://claude.com/claude-code)