### PR TITLE
Fix WiFi credentials wiped on every boot

### DIFF
--- a/src/wifi.cpp
+++ b/src/wifi.cpp
@@ -66,8 +66,6 @@ void doWiFi(bool dontUseStoredCreds)
         // blinker.attach_ms(STABLINK, wifiBlinker);
         wm.setConnectTimeout(30);
         wm.setConfigPortalTimeout(120);
-        // Disconnect any stale association first.
-        WiFi.disconnect(false);
         // ESPAsync_WiFiManager v1.15.1 crashes (Exception 28) when the stored
         // WiFi password is shorter than WPA minimum (8 chars) instead of
         // falling back to the config portal.  Pre-check here and erase bad


### PR DESCRIPTION
## Summary

`WiFi.disconnect(false)` was added in PR #24 to \"clear stale connection state\" before `autoConnect()`. On ESP8266, this call internally invokes `wifi_station_set_config()` with zeroed SSID/password. Because `WiFi.persistent()` defaults to `true`, this **writes empty credentials to flash on every boot**.

The result: portal saves credentials → device shows "Credentials Saved" → reboot → `WiFi.disconnect(false)` erases them from flash → `autoConnect()` finds nothing → portal opens again. Infinite loop.

Removing the call restores pre-PR#24 behaviour. The intentional short-password guard (`WiFi.disconnect(true)` inside the `psk.length() < 8` check) is kept — it only erases credentials when they are provably bad.

## Test plan

- [ ] Enter WiFi credentials in portal — device connects
- [ ] Reboot — device reconnects automatically without showing portal
- [ ] Power cycle — credentials still present, device connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)