### PR TITLE
Fix platformio lib URL, add VS Code tasks, fix default_2 template

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,103 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "PlatformIO: Build (1.4\" Red)",
+            "type": "shell",
+            "command": "pio run -e 1_4_inches_red",
+            "group": "build",
+            "problemMatcher": ["$gcc"]
+        },
+        {
+            "label": "PlatformIO: Build (1.4\" Green)",
+            "type": "shell",
+            "command": "pio run -e 1_4_inches_green",
+            "group": "build",
+            "problemMatcher": ["$gcc"]
+        },
+        {
+            "label": "PlatformIO: Build (1.4\" Direct)",
+            "type": "shell",
+            "command": "pio run -e 1_4_inches_direct",
+            "group": "build",
+            "problemMatcher": ["$gcc"]
+        },
+        {
+            "label": "PlatformIO: Build (1.7\")",
+            "type": "shell",
+            "command": "pio run -e 1_7_inches",
+            "group": "build",
+            "problemMatcher": ["$gcc"]
+        },
+        {
+            "label": "PlatformIO: Build (2\")",
+            "type": "shell",
+            "command": "pio run -e 2_inches",
+            "group": "build",
+            "problemMatcher": ["$gcc"]
+        },
+        {
+            "label": "PlatformIO: Build (2.4\" ILI9341)",
+            "type": "shell",
+            "command": "pio run -e 2_4_inches_ILI9341",
+            "group": "build",
+            "problemMatcher": ["$gcc"]
+        },
+        {
+            "label": "PlatformIO: Upload (1.4\" Red)",
+            "type": "shell",
+            "command": "pio run -e 1_4_inches_red -t upload",
+            "group": "build",
+            "problemMatcher": ["$gcc"]
+        },
+        {
+            "label": "PlatformIO: Upload (1.4\" Green)",
+            "type": "shell",
+            "command": "pio run -e 1_4_inches_green -t upload",
+            "group": "build",
+            "problemMatcher": ["$gcc"]
+        },
+        {
+            "label": "PlatformIO: Upload (1.4\" Direct)",
+            "type": "shell",
+            "command": "pio run -e 1_4_inches_direct -t upload",
+            "group": "build",
+            "problemMatcher": ["$gcc"]
+        },
+        {
+            "label": "PlatformIO: Upload (1.7\")",
+            "type": "shell",
+            "command": "pio run -e 1_7_inches -t upload",
+            "group": "build",
+            "problemMatcher": ["$gcc"]
+        },
+        {
+            "label": "PlatformIO: Upload (2\")",
+            "type": "shell",
+            "command": "pio run -e 2_inches -t upload",
+            "group": "build",
+            "problemMatcher": ["$gcc"]
+        },
+        {
+            "label": "PlatformIO: Upload (2.4\" ILI9341)",
+            "type": "shell",
+            "command": "pio run -e 2_4_inches_ILI9341 -t upload",
+            "group": "build",
+            "problemMatcher": ["$gcc"]
+        },
+        {
+            "label": "PlatformIO: Upload Filesystem",
+            "type": "shell",
+            "command": "pio run -t uploadfs",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "PlatformIO: Clean",
+            "type": "shell",
+            "command": "pio run -t clean",
+            "group": "build",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/data/data/templates/default_2.json
+++ b/data/data/templates/default_2.json
@@ -1,55 +1,50 @@
 {
-    "global": {
-        "back_color": "TFT_BLACK" ,
-        "font_color": "TFT_BLUE",
-        "text_wrap" : false
-
+    "g": {
+        "bc": "TFT_BLACK",
+        "fc": "TFT_WHITE",
+        "tw": false
     },
-    "line": {
-        "type": "text",
-        "font": "",
-        "color": "",
+    "line 1": {
+        "t": "text",
+        "f": "FreeSansGras12",
+        "c": "TFT_WHITE",
         "x": 0,
-        "y": 18,
-        "center": true,
+        "y": 10,
+        "ctr": true,
         "text": "SG: #SG"
     },
-    "line": {
-        "type": "text",
-        "font": "FreeSans9",
-        "color": "TFT_BLUE",
-        "x": 87,
-        "y": 50,
-        "center": true,
-        "text": "Voltage: #Voltage"
-    },
     "line 2": {
-        "type": "variable_text",
-        "font": "FreeSansGras12",
-        "variable" : "#RSSI",
-        "colors": {
-            "65": "TFT_GREEN",
-            "70": "TFT_YELLOW",
-            "80": "TFT_ORANGE",
-            "default": "TFT_RED"
-        },
+        "t": "text",
+        "f": "FreeSans9",
+        "c": "TFT_BLUE",
         "x": 0,
-        "y": 18,
-        "center": true,
-        "text": "Signal: #RSSI dB"
+        "y": 40,
+        "ctr": true,
+        "text": "Voltage: #VoltageV"
     },
     "line 3": {
-        "type": "rectangle",
-        "color": "TFT_MAGENTA",
-        "x_0": 0,
-        "y_0": 0,
-        "x_1": 128,
-        "y_1": 128
+        "t": "text",
+        "f": "FreeSans9",
+        "s": 1,
+        "var": "#RSSI",
+        "cs": [
+            {"val": 65, "col": "TFT_GREEN"},
+            {"val": 70, "col": "TFT_YELLOW"},
+            {"val": 80, "col": "TFT_ORANGE"}
+        ],
+        "def_col": "TFT_RED",
+        "x": 0,
+        "y": 65,
+        "ctr": true,
+        "text": "Signal: #RSSI dB"
     },
     "line 4": {
-        "type": "line",
-        "color": "TFT_YELLOW",
-        "x_0": 0,
-        "y_0": 0
+        "t": "text",
+        "f": "FreeSans9",
+        "c": "TFT_CYAN",
+        "x": 0,
+        "y": 90,
+        "ctr": true,
+        "text": "#deviceName"
     }
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -33,7 +33,7 @@ lib_deps =
 	bblanchon/StreamUtils@^1.6.3
 	bodmer/TFT_eSPI@2.5.43
 	arkhipenko/Dictionary @ ^3.5.0
-	khoih-prog/ESPAsync_WiFiManager
+	https://github.com/khoih-prog/ESPAsync_WiFiManager.git
 lib_ldf_mode = chain
 lib_ignore = ESP Async WebServer
 board_build.filesystem = littlefs


### PR DESCRIPTION
## Summary
- Switch `khoih-prog/ESPAsync_WiFiManager` dep to git URL so it tracks latest HEAD
- Add `.vscode/tasks.json` with build + upload tasks for all 6 screen environments (1.4\" red/green/direct, 1.7\", 2\", 2.4\" ILI9341) plus Upload Filesystem and Clean
- Rewrite `default_2.json` with the abbreviated key format the template parser expects (`g`, `t`, `c`, `ctr`, `f`, etc.); the old file used verbose keys (`global`, `type`, `color`, `center`, `font`) that hit the `"Entry in template not recognized"` branch on every iSpindel update

## Test plan
- [ ] Build succeeds with updated `ESPAsync_WiFiManager` git URL
- [ ] VS Code Run Task menu shows all 6 build + upload variants
- [ ] Selecting `default_2` template on the Display tab renders SG, Voltage, Signal, and device name without serial errors
- [ ] Upload `data/data/templates/default_2.json` via Settings > Display > Upload or `pio run -t uploadfs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)