### PR TITLE
docs: clarify var_text vs variable substitution in text lines

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -236,9 +236,7 @@ Leave `"f"` as `""` to keep the current font and use `"s"` for a size multiplier
 
 ## Not yet implemented
 
-The following type is parsed but not rendered:
-
-- **`"t": "var_text"`** — text whose content varies by value (stubbed, silently skipped)
+`"t": "var_text"` is recognised by the parser but silently skipped — no rendering code exists for it. Variable substitution (`#SG`, `#IP`, etc.) is fully supported inside ordinary `"t": "text"` lines and does not require this type.
 
 ---
 


### PR DESCRIPTION
Variable substitution in "t": "text" is fully implemented. Clarify that var_text is a different, stubbed type — not the same thing.