### PR TITLE
Fix WiFi credentials erased on every boot by ESPAsync_WiFiManager

### DIFF
--- a/src/wifi.cpp
+++ b/src/wifi.cpp
@@ -73,8 +73,18 @@ void doWiFi(bool dontUseStoredCreds)
         if (!WiFi.SSID().isEmpty() && WiFi.psk().length() > 0 && WiFi.psk().length() < 8) {
             Log.warning(F("Stored WiFi password too short (%d chars) — clearing to prevent WiFiManager crash." CR),
                         (int)WiFi.psk().length());
+            WiFi.persistent(true);
             WiFi.disconnect(true); // erase stored SSID/PSK
         }
+        // WiFi.disconnect() on ESP8266 with persistent=true (the default) calls
+        // wifi_station_set_config() with a zeroed struct, which writes blank
+        // credentials to flash.  ESPAsync_WiFiManager calls WiFi.disconnect()
+        // internally before every connection attempt, so without this guard it
+        // erases credentials on every boot.  Setting persistent=false makes all
+        // internal disconnects only modify the in-memory config, leaving flash
+        // untouched.  We restore persistent=true explicitly when we need to
+        // write (new portal credentials, or the short-password erase above).
+        WiFi.persistent(false);
         if (!wm.autoConnect(APNAME, APPWD))
         {
             Log.warning(F("Failed to connect and/or hit timeout." CR));
@@ -83,12 +93,20 @@ void doWiFi(bool dontUseStoredCreds)
         }
         else
         {
-            // We finished with portal (We were configured)
+            if (shouldSaveConfig)
+            {
+                // New credentials were entered in the config portal.
+                // Persist them to flash now that we know they work.
+                WiFi.persistent(true);
+                WiFi.begin(WiFi.SSID().c_str(), WiFi.psk().c_str());
+                WiFi.persistent(false);
+                Log.notice(F("New WiFi credentials saved to flash." CR));
+            }
+
             Log.notice(F("Get In Set HostName" CR));
             if (strlen(config.ispindhub.name) == 0)
             {
                 Log.notice(F(HOSTNAME CR));
-                // WiFi.setHostname(HOSTNAME);
                 WiFi.hostname(HOSTNAME);
                 WiFi.softAP(HOSTNAME, config.apconfig.passphrase);
             }
@@ -105,10 +123,6 @@ void doWiFi(bool dontUseStoredCreds)
             Log.notice(F("Get Out Set HostName" CR));
             saveConfig();
         }
-    }
-    if (shouldSaveConfig)
-    { // Save configuration
-      // Save configuration
     }
 
     Log.notice(F("Connected. IP address: %s." CR), WiFi.localIP().toString().c_str());


### PR DESCRIPTION
## Root cause

`WiFi.disconnect()` on ESP8266 with `WiFi.persistent(true)` (the SDK default) calls `wifi_station_set_config()` with a zeroed SSID/password struct, writing blank credentials to flash. The `wifioff` parameter only controls whether the radio is switched off — it has no effect on whether credentials are erased. ESPAsync_WiFiManager calls `WiFi.disconnect()` internally before every connection attempt, so stored credentials were silently wiped on every boot.

## Fix

- Set `WiFi.persistent(false)` before `wm.autoConnect()` so all internal disconnect calls only modify the in-memory config and never touch flash
- When the user saves new credentials via the config portal (`shouldSaveConfig == true`), explicitly set `persistent(true)`, call `WiFi.begin()` to write the verified credentials to flash, then set `persistent(false)` again

## Test plan
- [ ] Flash firmware, enter WiFi credentials in portal, verify device connects
- [ ] Power cycle — device should reconnect automatically without opening the portal
- [ ] Flash new firmware — credentials should survive the reflash
- [ ] Serial log should show `New WiFi credentials saved to flash.` only when credentials are entered via the portal, not on every boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)